### PR TITLE
Fix OEIC price data

### DIFF
--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-
+    
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -162,7 +162,7 @@ def upsert_transaction_into_portfolio(
     with duckdb.connect(database=DB_PATH) as conn:
         # Retrieve the security from the portfolio table based on the symbol
         result = conn.execute(
-            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
+            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio"
             "WHERE symbol = ?",
             (symbol,),
         ).fetchone()
@@ -267,7 +267,8 @@ def get_exchange_rate(
         url = f"https://api.frankfurter.app/latest?from={original_currency}&to={convert_to}"
     else:
         # Checks to see if data is available for the date provided
-        # Frankfurter API only provides exchange rate data since 4th January 1999.
+        # Frankfurter API only provides exchange rate data since 
+        # 4th January 1999.
         pdate = datetime.strptime(provided_date, "%Y-%m-%d").date()
         if pdate < date(1999, 1, 4):
             provided_date = "1999-01-04"
@@ -280,4 +281,7 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("0P0000KSPA.L"))
+    print(get_info("0P0001F96E.L")) # OEIC
+    print(get_info("AAPL")) # Company
+    print(get_info("^FTSE")) # Index
+    print(get_info("MKS.L")) # LSE stock

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-    
+
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -267,7 +267,7 @@ def get_exchange_rate(
         url = f"https://api.frankfurter.app/latest?from={original_currency}&to={convert_to}"
     else:
         # Checks to see if data is available for the date provided
-        # Frankfurter API only provides exchange rate data since 
+        # Frankfurter API only provides exchange rate data since
         # 4th January 1999.
         pdate = datetime.strptime(provided_date, "%Y-%m-%d").date()
         if pdate < date(1999, 1, 4):
@@ -281,7 +281,7 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("0P0001F96E.L")) # OEIC
-    print(get_info("AAPL")) # Company
-    print(get_info("^FTSE")) # Index
-    print(get_info("MKS.L")) # LSE stock
+    print(get_info("0P0001F96E.L"))  # OEIC
+    print(get_info("AAPL"))  # Company
+    print(get_info("^FTSE"))  # Index
+    print(get_info("MKS.L"))  # LSE stock

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-
+    
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -102,7 +102,14 @@ def get_info(symbol: str) -> dict[str, str]:
         return_dict["currency"] = ticker.info["financialCurrency"]
         return_dict["sector"] = ticker.info["sector"]
     except:
-        data = yf.download(return_dict["ticker"], period="1d", progress=False)
+        range = "1d"
+        
+        # If the type is a mutual fund then change the data download period to
+        # a month, as the value of the fund updates only once a day.
+        if return_dict["type"] == "MUTUALFUND":
+            range = "1mo"
+        
+        data = yf.download(return_dict["ticker"], period=range, progress=False)
         last_row_index = len(data) - 1
         # Gets the last reported close price of the asset
         last_row_open_value = data.iloc[last_row_index]["Close"]
@@ -273,5 +280,4 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("3697.T"))
-    print(get_info("GSK.L"))
+    print(get_info("0P0000KSPA.L"))

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-    
+
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -103,12 +103,12 @@ def get_info(symbol: str) -> dict[str, str]:
         return_dict["sector"] = ticker.info["sector"]
     except:
         range = "1d"
-        
+
         # If the type is a mutual fund then change the data download period to
-        # a month, as the value of the fund updates only once a day.
+        # a month, as the value of the fund updates only once a day.
         if return_dict["type"] == "MUTUALFUND":
             range = "1mo"
-        
+
         data = yf.download(return_dict["ticker"], period=range, progress=False)
         last_row_index = len(data) - 1
         # Gets the last reported close price of the asset

--- a/src/finance.py
+++ b/src/finance.py
@@ -97,7 +97,7 @@ def get_info(symbol: str) -> dict[str, str]:
     }
 
     # Tries to get information about a stock/index/fund but if the data is
-    # unavailable in the usual format, the most recent data about that asset is 
+    # unavailable in the usual format, the most recent data about that asset is
     # downloaded and retrieved using the download method of yfinance.
     try:
         return_dict["current_value"] = ticker.info["currentPrice"]

--- a/src/finance.py
+++ b/src/finance.py
@@ -96,12 +96,14 @@ def get_info(symbol: str) -> dict[str, str]:
         "type": ticker.info["quoteType"],
     }
 
-    # Gets information about a given index, security, or stock.
+    # Tries to get information about a stock/index/fund but if the data is
+    # unavailable in the usual format, the most recent data about that asset is 
+    # downloaded and retrieved using the download method of yfinance.
     try:
         return_dict["current_value"] = ticker.info["currentPrice"]
         return_dict["currency"] = ticker.info["financialCurrency"]
         return_dict["sector"] = ticker.info["sector"]
-    except:
+    except KeyError:
         range = "1d"
 
         # If the type is a mutual fund then change the data download period to
@@ -109,6 +111,7 @@ def get_info(symbol: str) -> dict[str, str]:
         if return_dict["type"] == "MUTUALFUND":
             range = "1mo"
 
+        # Downloads the most recent data associated with the asset.
         data = yf.download(return_dict["ticker"], period=range, progress=False)
         last_row_index = len(data) - 1
         # Gets the last reported close price of the asset

--- a/src/finance.py
+++ b/src/finance.py
@@ -162,7 +162,7 @@ def upsert_transaction_into_portfolio(
     with duckdb.connect(database=DB_PATH) as conn:
         # Retrieve the security from the portfolio table based on the symbol
         result = conn.execute(
-            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio"
+            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
             "WHERE symbol = ?",
             (symbol,),
         ).fetchone()


### PR DESCRIPTION
### Summary

- Previously, OEIC stock data was not retrieved correctly using yfinance and returned an error.
- This was fixed by changing the data download period from 1 week to 1 month when the type returned by yfinance is a mutual fund.

fixes #42.