### PR TITLE
Calculate breakdown of portfolio returns, fix value change calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ framework ensures cross-platform compatibility and high performance.
 
 ## Screenshots
 
-![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/75ba2678-fad5-4008-9b02-7f7fa8672449)
+![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/b028e543-4fe4-44c6-8c2e-5c48c395fd6e)
 
-![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/9925ca5e-a329-4272-afdd-37f5be1af746)
+![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/e0e24d49-de81-411a-b4b2-c227c4c8240b)
 
-<img src="https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/04021e7d-da5c-4ec2-abf4-4123254ee227" alt="Add a Transaction" width="500">
+<img src="https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/455492ae-924d-4611-aabb-feebc3463892" alt="Add a Transaction" width="500">
 
 ## Usage
 

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-
+    
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -162,7 +162,7 @@ def upsert_transaction_into_portfolio(
     with duckdb.connect(database=DB_PATH) as conn:
         # Retrieve the security from the portfolio table based on the symbol
         result = conn.execute(
-            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
+            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio"
             "WHERE symbol = ?",
             (symbol,),
         ).fetchone()
@@ -267,7 +267,8 @@ def get_exchange_rate(
         url = f"https://api.frankfurter.app/latest?from={original_currency}&to={convert_to}"
     else:
         # Checks to see if data is available for the date provided
-        # Frankfurter API only provides exchange rate data since 4th January 1999.
+        # Frankfurter API only provides exchange rate data since 
+        # 4th January 1999.
         pdate = datetime.strptime(provided_date, "%Y-%m-%d").date()
         if pdate < date(1999, 1, 4):
             provided_date = "1999-01-04"
@@ -280,4 +281,7 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("0P0000KSPA.L"))
+    print(get_info("0P0001F96E.L")) # OEIC
+    print(get_info("AAPL")) # Company
+    print(get_info("^FTSE")) # Index
+    print(get_info("MKS.L")) # LSE stock

--- a/src/finance.py
+++ b/src/finance.py
@@ -127,9 +127,9 @@ def get_info(symbol: str) -> dict[str, str]:
     return return_dict
 
 
-def get_absolute_rate_of_return(current: Decimal, purchase: Decimal) -> Decimal:
+def get_rate_of_return(current: Decimal, purchase: Decimal) -> Decimal:
     """
-    Calculates the absolute rate of return given the current and purchase price of an
+    Calculates the rate of return given the current and purchase price of an
     asset.
 
     Args:

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-    
+
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -267,7 +267,7 @@ def get_exchange_rate(
         url = f"https://api.frankfurter.app/latest?from={original_currency}&to={convert_to}"
     else:
         # Checks to see if data is available for the date provided
-        # Frankfurter API only provides exchange rate data since 
+        # Frankfurter API only provides exchange rate data since
         # 4th January 1999.
         pdate = datetime.strptime(provided_date, "%Y-%m-%d").date()
         if pdate < date(1999, 1, 4):
@@ -281,7 +281,7 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("0P0001F96E.L")) # OEIC
-    print(get_info("AAPL")) # Company
-    print(get_info("^FTSE")) # Index
-    print(get_info("MKS.L")) # LSE stock
+    print(get_info("0P0001F96E.L"))  # OEIC
+    print(get_info("AAPL"))  # Company
+    print(get_info("^FTSE"))  # Index
+    print(get_info("MKS.L"))  # LSE stock

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-
+    
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -102,7 +102,14 @@ def get_info(symbol: str) -> dict[str, str]:
         return_dict["currency"] = ticker.info["financialCurrency"]
         return_dict["sector"] = ticker.info["sector"]
     except:
-        data = yf.download(return_dict["ticker"], period="1d", progress=False)
+        range = "1d"
+        
+        # If the type is a mutual fund then change the data download period to
+        # a month, as the value of the fund updates only once a day.
+        if return_dict["type"] == "MUTUALFUND":
+            range = "1mo"
+        
+        data = yf.download(return_dict["ticker"], period=range, progress=False)
         last_row_index = len(data) - 1
         # Gets the last reported close price of the asset
         last_row_open_value = data.iloc[last_row_index]["Close"]
@@ -273,5 +280,4 @@ def get_exchange_rate(
 
 
 if __name__ == "__main__":
-    print(get_info("3697.T"))
-    print(get_info("GSK.L"))
+    print(get_info("0P0000KSPA.L"))

--- a/src/finance.py
+++ b/src/finance.py
@@ -88,7 +88,7 @@ def get_info(symbol: str) -> dict[str, str]:
         ticker = yf.Ticker(symbol)
     except:
         return False
-    
+
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
         "name": ticker.info["shortName"],
@@ -103,12 +103,12 @@ def get_info(symbol: str) -> dict[str, str]:
         return_dict["sector"] = ticker.info["sector"]
     except:
         range = "1d"
-        
+
         # If the type is a mutual fund then change the data download period to
-        # a month, as the value of the fund updates only once a day.
+        # a month, as the value of the fund updates only once a day.
         if return_dict["type"] == "MUTUALFUND":
             range = "1mo"
-        
+
         data = yf.download(return_dict["ticker"], period=range, progress=False)
         last_row_index = len(data) - 1
         # Gets the last reported close price of the asset

--- a/src/finance.py
+++ b/src/finance.py
@@ -162,7 +162,7 @@ def upsert_transaction_into_portfolio(
     with duckdb.connect(database=DB_PATH) as conn:
         # Retrieve the security from the portfolio table based on the symbol
         result = conn.execute(
-            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio"
+            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
             "WHERE symbol = ?",
             (symbol,),
         ).fetchone()

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -400,26 +400,29 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
             exchange_rate = get_exchange_rate(stock_info["currency"])
             total_cur_val_gbp += cur_val * exchange_rate
 
+        # Absolute rate of return
         rate_of_return_absolute = get_rate_of_return(total_cur_val_gbp, total_paid_gbp)
+        self.table_widget_returns_breakdown.setItem(
+            0, 0, QtWidgets.QTableWidgetItem(f"{rate_of_return_absolute:.3f}%")
+        )
+        # Return from change in value
         val_change_return = get_rate_of_return(total_cur_val, total_paid)
+        self.table_widget_returns_breakdown.setItem(
+            0, 1, QtWidgets.QTableWidgetItem(f"{val_change_return:.3f}%")
+        )
+        # Return from currency risk
         # Currency risk is the returns caused by fluctuations in the exchange
         # rate between the currency of the security and GBP since the
         # security was purchased. If the GBP has weakened against the original
         # currency, it results in a positive return, and vice versa.
         currency_risk_return = rate_of_return_absolute - val_change_return
-
-        # Absolute rate of return
-        self.table_widget_returns_breakdown.setItem(
-            0, 0, QtWidgets.QTableWidgetItem(f"{rate_of_return_absolute:.3f}%")
-        )
-        # Return from change in value
-        self.table_widget_returns_breakdown.setItem(
-            0, 1, QtWidgets.QTableWidgetItem(f"{val_change_return:.3f}%")
-        )
-        # Return from currency risk
         self.table_widget_returns_breakdown.setItem(
             0, 2, QtWidgets.QTableWidgetItem(f"{currency_risk_return:.3f}%")
         )
+
+        # Get the current time in DD/MM/YYYY HH:MM:SS format.
+        cur_time = time.strftime("%d/%m/%Y %H:%M:%S")
+        self.lbl_last_updated.setText(f"Last Updated: {cur_time}")
 
 
 class TransactionHistoryDialog(QDialog, Ui_dialog_transaction_history):

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -18,15 +18,16 @@ from PySide6.QtWidgets import QDialog, QMainWindow
 
 from src.finance import (
     get_absolute_rate_of_return,
+    get_exchange_rate,
     get_info,
     get_name_from_symbol,
     get_total_paid_into_portfolio,
     upsert_transaction_into_portfolio,
-    get_exchange_rate,
 )
 from src.transactions import Transaction
 from src.ui.add_transaction_ui import Ui_dialog_add_transaction
 from src.ui.main_window_ui import Ui_main_window
+from src.ui.portfolio_performance_ui import Ui_dialog_portfolio_perf
 from src.ui.transaction_history_ui import Ui_dialog_transaction_history
 
 DB_PATH = "resources/portfolio.db"
@@ -78,6 +79,8 @@ class MainWindow(QMainWindow, Ui_main_window):
         self.btn_add_transaction.clicked.connect(self.open_add_transaction_dialog)
         # Connect the 'View Transactions' button to open the dialog.
         self.btn_view_transactions.clicked.connect(self.open_transaction_history_dialog)
+        # Connect the 'Analyse Portfolio Performance' button.
+        self.btn_view_portfolio_perf.clicked.connect(self.open_portfolio_perf_dialog)
 
         # Set the resize mode of the table to resize the columns to fit
         # the contents by default.
@@ -135,6 +138,13 @@ class MainWindow(QMainWindow, Ui_main_window):
         """
         self.transaction_history_dialog = TransactionHistoryDialog()
         self.transaction_history_dialog.open()
+
+    def open_portfolio_perf_dialog(self) -> None:
+        """
+        Open the dialog to view the user's portfolio performance analysis.
+        """
+        self.portfolio_perf_dialog = PortfolioPerfDialog()
+        self.portfolio_perf_dialog.open()
 
     def update_returns_table(self) -> None:
         """
@@ -353,6 +363,12 @@ class MainWindow(QMainWindow, Ui_main_window):
         # Update last updated time label in dd-mm-yyyy hh:mm:ss format
         cur_time = time.strftime("%d/%m/%Y %H:%M:%S")
         self.lbl_last_updated.setText(f"Last Updated: {cur_time}")
+
+
+class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setupUi(self)
 
 
 class TransactionHistoryDialog(QDialog, Ui_dialog_transaction_history):

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -370,6 +370,13 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
         super().__init__()
         self.setupUi(self)
 
+        # Set the resize mode of the table to resize the columns to fit
+        # the contents by default.
+        table_header = self.table_widget_returns_breakdown.horizontalHeader()
+        table_header.setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+
 
 class TransactionHistoryDialog(QDialog, Ui_dialog_transaction_history):
     def __init__(self) -> None:

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -17,7 +17,7 @@ from PySide6.QtGui import QDoubleValidator
 from PySide6.QtWidgets import QDialog, QMainWindow
 
 from src.finance import (
-    get_absolute_rate_of_return,
+    get_rate_of_return,
     get_exchange_rate,
     get_info,
     get_name_from_symbol,
@@ -161,7 +161,7 @@ class MainWindow(QMainWindow, Ui_main_window):
         total_val_change = Decimal(
             sum(self.current_security_info[security.name][1] for security in portfolio)
         )
-        rate_of_return_absolute = get_absolute_rate_of_return(total_cur_val, total_paid)
+        rate_of_return_absolute = get_rate_of_return(total_cur_val, total_paid)
 
         # Update the table with the new values.
         self.table_widget_returns.setItem(
@@ -267,7 +267,7 @@ class MainWindow(QMainWindow, Ui_main_window):
             cur_val_gbp = cur_val * exchange_rate
 
             val_change = cur_val_gbp - (security.paid * exchange_rate)
-            rate_of_return_abs = get_absolute_rate_of_return(cur_val, security.paid)
+            rate_of_return_abs = get_rate_of_return(cur_val, security.paid)
 
             # Stores the live security information in a dictionary indexed
             # by the name of the security
@@ -400,8 +400,8 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
             total_cur_val_gbp += cur_val * exchange_rate
             total_paid_gbp += security.paid * exchange_rate
 
-        rate_of_return_absolute = get_absolute_rate_of_return(total_cur_val_gbp, total_paid_gbp)
-        val_change_return = get_absolute_rate_of_return(total_cur_val, total_paid)
+        rate_of_return_absolute = get_rate_of_return(total_cur_val_gbp, total_paid_gbp)
+        val_change_return = get_rate_of_return(total_cur_val, total_paid)
         print(total_cur_val)
         print(total_cur_val_gbp)
         print(total_paid)

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -387,6 +387,7 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
         total_cur_val = Decimal(0.0)
         total_cur_val_gbp = Decimal(0.0)
         total_paid = Decimal(0.0)
+        total_paid_gbp = Decimal(0.0)
 
         # Calculate the cumulative total paid and current value of the
         # portfolio.
@@ -394,16 +395,17 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
             stock_info = get_info(security.symbol)
             cur_val = Decimal(stock_info["current_value"]) * security.units
             total_cur_val += cur_val
+            total_paid += security.paid
             exchange_rate = get_exchange_rate(stock_info["currency"])
             total_cur_val_gbp += cur_val * exchange_rate
+            total_paid_gbp += security.paid * exchange_rate
 
-        total_paid = get_total_paid_into_portfolio()
-        total_val_change = total_cur_val_gbp - total_paid
-        rate_of_return_absolute = get_absolute_rate_of_return(
-            total_cur_val_gbp, total_paid
-        )
-        # TODO: Change this to exclude currency risk.
-        val_change_return = (total_val_change / total_paid) * Decimal(100.0)
+        rate_of_return_absolute = get_absolute_rate_of_return(total_cur_val_gbp, total_paid_gbp)
+        val_change_return = get_absolute_rate_of_return(total_cur_val, total_paid)
+        print(total_cur_val)
+        print(total_cur_val_gbp)
+        print(total_paid)
+        print(total_paid_gbp)
 
         # Absolute rate of return
         self.table_widget_returns_breakdown.setItem(

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -396,16 +396,17 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
             cur_val = Decimal(stock_info["current_value"]) * security.units
             total_cur_val += cur_val
             total_paid += security.paid
+            total_paid_gbp += security.paid_gbp
             exchange_rate = get_exchange_rate(stock_info["currency"])
             total_cur_val_gbp += cur_val * exchange_rate
-            total_paid_gbp += security.paid * exchange_rate
 
         rate_of_return_absolute = get_rate_of_return(total_cur_val_gbp, total_paid_gbp)
         val_change_return = get_rate_of_return(total_cur_val, total_paid)
-        print(total_cur_val)
-        print(total_cur_val_gbp)
-        print(total_paid)
-        print(total_paid_gbp)
+        # Currency risk is the returns caused by fluctuations in the exchange
+        # rate between the currency of the security and GBP since the
+        # security was purchased. If the GBP has weakened against the original
+        # currency, it results in a positive return, and vice versa.
+        currency_risk_return = rate_of_return_absolute - val_change_return
 
         # Absolute rate of return
         self.table_widget_returns_breakdown.setItem(
@@ -413,11 +414,11 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
         )
         # Return from change in value
         self.table_widget_returns_breakdown.setItem(
-            0, 1, QtWidgets.QTableWidgetItem(f"{val_change_return:.2f}%")
+            0, 1, QtWidgets.QTableWidgetItem(f"{val_change_return:.3f}%")
         )
         # Return from currency risk
         self.table_widget_returns_breakdown.setItem(
-            0, 2, QtWidgets.QTableWidgetItem(f"")
+            0, 2, QtWidgets.QTableWidgetItem(f"{currency_risk_return:.3f}%")
         )
 
 

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -266,8 +266,8 @@ class MainWindow(QMainWindow, Ui_main_window):
             exchange_rate = get_exchange_rate(stock_info["currency"])
             cur_val_gbp = cur_val * exchange_rate
 
-            val_change = cur_val_gbp - (security.paid * exchange_rate)
-            rate_of_return_abs = get_rate_of_return(cur_val, security.paid)
+            val_change = cur_val_gbp - security.paid_gbp
+            rate_of_return_abs = get_rate_of_return(cur_val_gbp, security.paid)
 
             # Stores the live security information in a dictionary indexed
             # by the name of the security
@@ -597,6 +597,7 @@ class HeldSecurity:
     units: Decimal
     currency: str
     paid: Decimal
+    paid_gbp: Decimal
 
     @staticmethod
     def load_portfolio() -> list[HeldSecurity]:
@@ -610,19 +611,20 @@ class HeldSecurity:
         with duckdb.connect(database=DB_PATH) as conn:
             # Retrieve securities from the portfolio table
             result = conn.execute(
-                "SELECT symbol, name, units, currency, paid FROM portfolio"
+                "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio"
             )
             records = result.fetchall()
 
         # Create HeldSecurity objects for each record.
         portfolio = []
         for record in records:
-            symbol, name, units, currency, paid = record
+            symbol, name, units, currency, paid, paid_gbp = record
             # Convert the units and paid values to Decimal objects to avoid
             # floating point precision errors.
             units = Decimal(units)
             paid = Decimal(paid)
-            security = HeldSecurity(symbol, name, units, currency, paid)
+            paid_gbp = Decimal(paid_gbp)
+            security = HeldSecurity(symbol, name, units, currency, paid, paid_gbp)
             portfolio.append(security)
 
         return portfolio

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -392,14 +392,18 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
         # portfolio.
         for security in portfolio:
             stock_info = get_info(security.symbol)
-            # TODO: This field mixes pounds and pence - fix this.
-            total_paid += Decimal(security.paid)
-            total_cur_val += Decimal(stock_info["current_value"]) * security.units
+            cur_val = Decimal(stock_info["current_value"]) * security.units
+            total_cur_val += cur_val
             exchange_rate = get_exchange_rate(stock_info["currency"])
-            total_cur_val_gbp += total_cur_val * exchange_rate
+            total_cur_val_gbp += cur_val * exchange_rate
 
+        total_paid = get_total_paid_into_portfolio()
         total_val_change = total_cur_val_gbp - total_paid
-        rate_of_return_absolute = get_absolute_rate_of_return(total_cur_val, total_paid)
+        rate_of_return_absolute = get_absolute_rate_of_return(
+            total_cur_val_gbp, total_paid
+        )
+        # TODO: Change this to exclude currency risk.
+        val_change_return = (total_val_change / total_paid) * Decimal(100.0)
 
         # Absolute rate of return
         self.table_widget_returns_breakdown.setItem(
@@ -407,7 +411,7 @@ class PortfolioPerfDialog(QDialog, Ui_dialog_portfolio_perf):
         )
         # Return from change in value
         self.table_widget_returns_breakdown.setItem(
-            0, 1, QtWidgets.QTableWidgetItem(f"{total_val_change:.2f}")
+            0, 1, QtWidgets.QTableWidgetItem(f"{val_change_return:.2f}%")
         )
         # Return from currency risk
         self.table_widget_returns_breakdown.setItem(

--- a/src/ui/add_transaction.ui
+++ b/src/ui/add_transaction.ui
@@ -16,7 +16,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Add a Transaction – Trading Portfolio Tracker</string>
+   <string>Trading Portfolio Tracker – Add a Transaction</string>
   </property>
   <widget class="QWidget" name="verticalLayoutWidget">
    <property name="geometry">

--- a/src/ui/add_transaction_ui.py
+++ b/src/ui/add_transaction_ui.py
@@ -169,7 +169,7 @@ class Ui_dialog_add_transaction(object):
     # setupUi
 
     def retranslateUi(self, dialog_add_transaction):
-        dialog_add_transaction.setWindowTitle(QCoreApplication.translate("dialog_add_transaction", u"Add a Transaction \u2013 Trading Portfolio Tracker", None))
+        dialog_add_transaction.setWindowTitle(QCoreApplication.translate("dialog_add_transaction", u"Trading Portfolio Tracker \u2013\u00a0Add a Transaction", None))
         self.lbl_add_transaction.setText(QCoreApplication.translate("dialog_add_transaction", u"Add a Transaction", None))
         self.lbl_transaction_type.setText(QCoreApplication.translate("dialog_add_transaction", u"Transaction Type:", None))
         self.combo_box_transaction_type.setItemText(0, QCoreApplication.translate("dialog_add_transaction", u"Buy", None))

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
-    <height>600</height>
+    <width>1200</width>
+    <height>800</height>
    </rect>
   </property>
   <property name="font">
@@ -24,8 +24,8 @@
      <rect>
       <x>10</x>
       <y>10</y>
-      <width>1002</width>
-      <height>1042</height>
+      <width>1181</width>
+      <height>781</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="vert_layout_window">

--- a/src/ui/main_window_ui.py
+++ b/src/ui/main_window_ui.py
@@ -24,7 +24,7 @@ class Ui_main_window(object):
     def setupUi(self, main_window):
         if not main_window.objectName():
             main_window.setObjectName(u"main_window")
-        main_window.resize(1000, 600)
+        main_window.resize(1200, 800)
         font = QFont()
         font.setPointSize(12)
         main_window.setFont(font)
@@ -32,7 +32,7 @@ class Ui_main_window(object):
         self.central_widget.setObjectName(u"central_widget")
         self.verticalLayoutWidget = QWidget(self.central_widget)
         self.verticalLayoutWidget.setObjectName(u"verticalLayoutWidget")
-        self.verticalLayoutWidget.setGeometry(QRect(10, 10, 1002, 1042))
+        self.verticalLayoutWidget.setGeometry(QRect(10, 10, 1181, 781))
         self.vert_layout_window = QVBoxLayout(self.verticalLayoutWidget)
         self.vert_layout_window.setObjectName(u"vert_layout_window")
         self.vert_layout_window.setContentsMargins(0, 0, 0, 0)

--- a/src/ui/portfolio_performance.ui
+++ b/src/ui/portfolio_performance.ui
@@ -96,12 +96,12 @@
       </column>
       <column>
        <property name="text">
-        <string>Returns from Currency Risk</string>
+        <string>Returns from Change of Value</string>
        </property>
       </column>
       <column>
        <property name="text">
-        <string>Returns from Change of Value</string>
+        <string>Returns from Currency Risk</string>
        </property>
       </column>
       <item row="0" column="0">

--- a/src/ui/portfolio_performance.ui
+++ b/src/ui/portfolio_performance.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dialog_portfolio_perf</class>
+ <widget class="QDialog" name="dialog_portfolio_perf">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>12</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Trading Portfolio Tracker – Portfolio Performance Analysis</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>6</y>
+     <width>781</width>
+     <height>581</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="vert_layout_dialog">
+    <item>
+     <widget class="QLabel" name="lbl_portfolio_perf">
+      <property name="font">
+       <font>
+        <pointsize>22</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Portfolio Performance Analysis</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="Line" name="hori_line_portfolio_perf">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="lbl_last_updated">
+      <property name="text">
+       <string>Last Updated: DD/MM/YYYY HH:MM:SS</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="Line" name="hori_line_last_updated">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="lbl_returns_breakdown">
+      <property name="font">
+       <font>
+        <pointsize>16</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Breakdown of Returns</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QTableWidget" name="table_widget_returns_breakdown">
+      <property name="showGrid">
+       <bool>true</bool>
+      </property>
+      <property name="cornerButtonEnabled">
+       <bool>false</bool>
+      </property>
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
+      <row>
+       <property name="text">
+        <string>Values</string>
+       </property>
+      </row>
+      <column>
+       <property name="text">
+        <string>Rate of Return (Absolute)</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Returns from Currency Risk</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Returns from Change of Value</string>
+       </property>
+      </column>
+      <item row="0" column="0">
+       <property name="text">
+        <string>N/A</string>
+       </property>
+      </item>
+      <item row="0" column="1">
+       <property name="text">
+        <string>N/A</string>
+       </property>
+      </item>
+      <item row="0" column="2">
+       <property name="text">
+        <string>N/A</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item>
+     <spacer name="vert_spacer_dialog">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/portfolio_performance.ui
+++ b/src/ui/portfolio_performance.ui
@@ -91,7 +91,7 @@
       </row>
       <column>
        <property name="text">
-        <string>Rate of Return (Absolute)</string>
+        <string>Total Rate of Return (Absolute)</string>
        </property>
       </column>
       <column>

--- a/src/ui/portfolio_performance_ui.py
+++ b/src/ui/portfolio_performance_ui.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'portfolio_performance.ui'
+##
+## Created by: Qt User Interface Compiler version 6.5.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QDialog, QFrame, QHeaderView,
+    QLabel, QSizePolicy, QSpacerItem, QTableWidget,
+    QTableWidgetItem, QVBoxLayout, QWidget)
+
+class Ui_dialog_portfolio_perf(object):
+    def setupUi(self, dialog_portfolio_perf):
+        if not dialog_portfolio_perf.objectName():
+            dialog_portfolio_perf.setObjectName(u"dialog_portfolio_perf")
+        dialog_portfolio_perf.resize(800, 600)
+        font = QFont()
+        font.setPointSize(12)
+        dialog_portfolio_perf.setFont(font)
+        self.verticalLayoutWidget = QWidget(dialog_portfolio_perf)
+        self.verticalLayoutWidget.setObjectName(u"verticalLayoutWidget")
+        self.verticalLayoutWidget.setGeometry(QRect(10, 6, 781, 581))
+        self.vert_layout_dialog = QVBoxLayout(self.verticalLayoutWidget)
+        self.vert_layout_dialog.setObjectName(u"vert_layout_dialog")
+        self.vert_layout_dialog.setContentsMargins(0, 0, 0, 0)
+        self.lbl_portfolio_perf = QLabel(self.verticalLayoutWidget)
+        self.lbl_portfolio_perf.setObjectName(u"lbl_portfolio_perf")
+        font1 = QFont()
+        font1.setPointSize(22)
+        self.lbl_portfolio_perf.setFont(font1)
+
+        self.vert_layout_dialog.addWidget(self.lbl_portfolio_perf)
+
+        self.hori_line_portfolio_perf = QFrame(self.verticalLayoutWidget)
+        self.hori_line_portfolio_perf.setObjectName(u"hori_line_portfolio_perf")
+        self.hori_line_portfolio_perf.setFrameShape(QFrame.HLine)
+        self.hori_line_portfolio_perf.setFrameShadow(QFrame.Sunken)
+
+        self.vert_layout_dialog.addWidget(self.hori_line_portfolio_perf)
+
+        self.lbl_last_updated = QLabel(self.verticalLayoutWidget)
+        self.lbl_last_updated.setObjectName(u"lbl_last_updated")
+
+        self.vert_layout_dialog.addWidget(self.lbl_last_updated)
+
+        self.hori_line_last_updated = QFrame(self.verticalLayoutWidget)
+        self.hori_line_last_updated.setObjectName(u"hori_line_last_updated")
+        self.hori_line_last_updated.setFrameShape(QFrame.HLine)
+        self.hori_line_last_updated.setFrameShadow(QFrame.Sunken)
+
+        self.vert_layout_dialog.addWidget(self.hori_line_last_updated)
+
+        self.lbl_returns_breakdown = QLabel(self.verticalLayoutWidget)
+        self.lbl_returns_breakdown.setObjectName(u"lbl_returns_breakdown")
+        font2 = QFont()
+        font2.setPointSize(16)
+        self.lbl_returns_breakdown.setFont(font2)
+
+        self.vert_layout_dialog.addWidget(self.lbl_returns_breakdown)
+
+        self.table_widget_returns_breakdown = QTableWidget(self.verticalLayoutWidget)
+        if (self.table_widget_returns_breakdown.columnCount() < 3):
+            self.table_widget_returns_breakdown.setColumnCount(3)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        if (self.table_widget_returns_breakdown.rowCount() < 1):
+            self.table_widget_returns_breakdown.setRowCount(1)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setVerticalHeaderItem(0, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setItem(0, 0, __qtablewidgetitem4)
+        __qtablewidgetitem5 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setItem(0, 1, __qtablewidgetitem5)
+        __qtablewidgetitem6 = QTableWidgetItem()
+        self.table_widget_returns_breakdown.setItem(0, 2, __qtablewidgetitem6)
+        self.table_widget_returns_breakdown.setObjectName(u"table_widget_returns_breakdown")
+        self.table_widget_returns_breakdown.setShowGrid(True)
+        self.table_widget_returns_breakdown.setCornerButtonEnabled(False)
+        self.table_widget_returns_breakdown.verticalHeader().setVisible(False)
+
+        self.vert_layout_dialog.addWidget(self.table_widget_returns_breakdown)
+
+        self.vert_spacer_dialog = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+
+        self.vert_layout_dialog.addItem(self.vert_spacer_dialog)
+
+
+        self.retranslateUi(dialog_portfolio_perf)
+
+        QMetaObject.connectSlotsByName(dialog_portfolio_perf)
+    # setupUi
+
+    def retranslateUi(self, dialog_portfolio_perf):
+        dialog_portfolio_perf.setWindowTitle(QCoreApplication.translate("dialog_portfolio_perf", u"Trading Portfolio Tracker \u2013\u00a0Portfolio Performance Analysis", None))
+        self.lbl_portfolio_perf.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Portfolio Performance Analysis", None))
+        self.lbl_last_updated.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Last Updated: DD/MM/YYYY HH:MM:SS", None))
+        self.lbl_returns_breakdown.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Breakdown of Returns", None))
+        ___qtablewidgetitem = self.table_widget_returns_breakdown.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Rate of Return (Absolute)", None));
+        ___qtablewidgetitem1 = self.table_widget_returns_breakdown.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Currency Risk", None));
+        ___qtablewidgetitem2 = self.table_widget_returns_breakdown.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Change of Value", None));
+        ___qtablewidgetitem3 = self.table_widget_returns_breakdown.verticalHeaderItem(0)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Values", None));
+
+        __sortingEnabled = self.table_widget_returns_breakdown.isSortingEnabled()
+        self.table_widget_returns_breakdown.setSortingEnabled(False)
+        ___qtablewidgetitem4 = self.table_widget_returns_breakdown.item(0, 0)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("dialog_portfolio_perf", u"N/A", None));
+        ___qtablewidgetitem5 = self.table_widget_returns_breakdown.item(0, 1)
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("dialog_portfolio_perf", u"N/A", None));
+        ___qtablewidgetitem6 = self.table_widget_returns_breakdown.item(0, 2)
+        ___qtablewidgetitem6.setText(QCoreApplication.translate("dialog_portfolio_perf", u"N/A", None));
+        self.table_widget_returns_breakdown.setSortingEnabled(__sortingEnabled)
+
+    # retranslateUi
+

--- a/src/ui/portfolio_performance_ui.py
+++ b/src/ui/portfolio_performance_ui.py
@@ -112,9 +112,9 @@ class Ui_dialog_portfolio_perf(object):
         ___qtablewidgetitem = self.table_widget_returns_breakdown.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Rate of Return (Absolute)", None));
         ___qtablewidgetitem1 = self.table_widget_returns_breakdown.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Currency Risk", None));
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Change of Value", None));
         ___qtablewidgetitem2 = self.table_widget_returns_breakdown.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Change of Value", None));
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Currency Risk", None));
         ___qtablewidgetitem3 = self.table_widget_returns_breakdown.verticalHeaderItem(0)
         ___qtablewidgetitem3.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Values", None));
 

--- a/src/ui/portfolio_performance_ui.py
+++ b/src/ui/portfolio_performance_ui.py
@@ -110,7 +110,7 @@ class Ui_dialog_portfolio_perf(object):
         self.lbl_last_updated.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Last Updated: DD/MM/YYYY HH:MM:SS", None))
         self.lbl_returns_breakdown.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Breakdown of Returns", None))
         ___qtablewidgetitem = self.table_widget_returns_breakdown.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Rate of Return (Absolute)", None));
+        ___qtablewidgetitem.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Total Rate of Return (Absolute)", None));
         ___qtablewidgetitem1 = self.table_widget_returns_breakdown.horizontalHeaderItem(1)
         ___qtablewidgetitem1.setText(QCoreApplication.translate("dialog_portfolio_perf", u"Returns from Change of Value", None));
         ___qtablewidgetitem2 = self.table_widget_returns_breakdown.horizontalHeaderItem(2)


### PR DESCRIPTION
## Changes
- Calculated the breakdown of portfolio returns based on:
  - Total rate of return
  - Returns from change of value
  - Returns from currency risk
- Fixed value change calculation in the portfolio view.
  - Previously, the calculations mixed up the currencies and assumed that the exchange rate was always the same as today's exchange rate, causing incorrect results.
- Updated the README with new sample data with fixed values.

## Related Issues
- Fixes [#44](https://github.com/IsaacCheng9/trading-portfolio-tracker/issues/44)

## Screenshots
In this example, GOOGL was bought in 2021 when GBP was stronger against USD. Thus, currency risk caused the returns to be less negative than they would otherwise be – GOOGL is denominated in USD, and 1 USD now exchanges to more GBP than in 2021.

![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/114e032a-8e4d-408f-869f-ee737d1253da)

![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/cf0e445a-59e1-47a9-8053-84421e8592c3)

![image](https://github.com/IsaacCheng9/trading-portfolio-tracker/assets/47993930/05f402be-fc3c-4f2c-bf6e-3ad495faf2c5)
