### PR TITLE
Add non-database unit tests for yfinance calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage==7.2.3
 duckdb==0.8.1
 pandas==1.4.0
-PySide6==6.5.1.1
+PySide6==6.5.2
 pytest==7.3.1
 requests==2.31.0
-yfinance==0.2.20
+yfinance==0.2.26

--- a/src/app.py
+++ b/src/app.py
@@ -22,12 +22,12 @@ def main() -> None:
     sys.exit(app.exec())
 
 
-def create_database_tables() -> None:
+def create_database_tables(database_path: str = DB_PATH) -> None:
     """
     Create the database tables if they don't already exist.
     """
     # Create a table to store securities in the user's portfolio.
-    with duckdb.connect(database=DB_PATH) as conn:
+    with duckdb.connect(database=database_path) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS portfolio ("
             "symbol TEXT PRIMARY KEY, "
@@ -40,7 +40,7 @@ def create_database_tables() -> None:
         )
 
     # Create a table to store the transactions made by the user.
-    with duckdb.connect(database=DB_PATH) as conn:
+    with duckdb.connect(database=database_path) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS transaction ("
             "transaction_id TEXT PRIMARY KEY, "

--- a/src/finance.py
+++ b/src/finance.py
@@ -48,7 +48,7 @@ def get_name_from_symbol(symbol: str) -> str:
     """
     tick = yf.Ticker(symbol)
     try:
-        name = tick.info["shortName"]
+        name = tick.info["longName"]
         return name
     except (exceptions.HTTPError, KeyError):
         return ""

--- a/src/finance.py
+++ b/src/finance.py
@@ -84,10 +84,7 @@ def get_info(symbol: str) -> dict[str, str]:
         Dictionary containing information about the stock, future, or index.
     """
     # Creates a yfinance ticker object for a given asset.
-    try:
-        ticker = yf.Ticker(symbol)
-    except:
-        return False
+    ticker = yf.Ticker(symbol)
 
     # Creates a dictionary containing basic information about the asset.
     return_dict = {

--- a/src/finance.py
+++ b/src/finance.py
@@ -146,7 +146,7 @@ def upsert_transaction_into_portfolio(
     amount: Decimal,
     unit_price: Decimal,
     amount_gbp: Decimal,
-    database_path: str = DB_PATH
+    database_path: str = DB_PATH,
 ) -> None:
     """
     Update/insert the portfolio based on a new transaction.
@@ -218,10 +218,7 @@ def upsert_transaction_into_portfolio(
             )
 
 
-def remove_security_from_portfolio(
-    symbol: str, 
-    database_path: str = DB_PATH
-    ) -> None:
+def remove_security_from_portfolio(symbol: str, database_path: str = DB_PATH) -> None:
     """
     Remove the security from the portfolio table.
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -169,11 +169,11 @@ def test_get_info_invalid() -> None:
         (0, 0, 0),
     ],
 )
-def test_get_absolute_rate_of_return_valid(
+def test_get_rate_of_return_valid(
     current: float, purchase: float, expected_result: float
 ) -> None:
     """
-    Tests the get_absolute_rate_of_return method using valid current and
+    Tests the get_rate_of_return method using valid current and
     purchase prices of an asset.
 
     Args:
@@ -181,25 +181,25 @@ def test_get_absolute_rate_of_return_valid(
         purchase: Purchase price of the asset.
         expected_result: Expected absolute rate of return
     """
-    calculated_ror = finance.get_absolute_rate_of_return(current, purchase)
+    calculated_ror = finance.get_rate_of_return(current, purchase)
     assert calculated_ror == expected_result
 
 
-def test_get_absolute_rate_of_return_no_purchase_price() -> None:
+def test_get_rate_of_return_no_purchase_price() -> None:
     """
-    Tests the get_absolute_rate_of_return method whilst passing no purchase
+    Tests the get_rate_of_return method whilst passing no purchase
     price into the method.
     """
-    calculated_ror = finance.get_absolute_rate_of_return(100, None)
+    calculated_ror = finance.get_rate_of_return(100, None)
     assert calculated_ror == 0
 
 
-def test_get_absolute_rate_of_return_invalid() -> None:
+def test_get_rate_of_return_invalid() -> None:
     """
-    Tests the get_absolute_rate_of_return method whilst passing no purchase
+    Tests the get_rate_of_return method whilst passing no purchase
     and current price into the method
     """
-    calculated_ror = finance.get_absolute_rate_of_return(None, None)
+    calculated_ror = finance.get_rate_of_return(None, None)
     assert calculated_ror == 0
 
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,6 +1,8 @@
 import pytest
 import pandas as pd
+import yfinance as yf
 
+from requests import exceptions
 from src import finance
 
 
@@ -16,14 +18,24 @@ from src import finance
     ],
 )
 def test_get_symbol_valid(name: str, expected_result: str) -> None:
-    """ """
+    """
+    Tests the get_symbol method with valid company/index/fund names to assert
+    the correct symbol is returned.
+
+    Args:
+        name: Name of the company/index/fund.
+        expected_result: Expected symbol to be returned (AAPL...).
+    """
     symbol = finance.get_symbol(name)
     assert type(symbol) is str
     assert symbol == expected_result
 
 
 def test_get_symbol_invalid() -> None:
-    """ """
+    """
+    Tests the get_symbol method with an invalid name to assert an appropriate
+    error is thrown.
+    """
     try:
         finance.get_symbol("Invalid")
         assert False
@@ -43,28 +55,140 @@ def test_get_symbol_invalid() -> None:
     ],
 )
 def test_get_name_from_symbol_valid(symbol: str, expected_result: str) -> None:
-    """ """
+    """
+    Tests the get_name_from_symbol method with valid company/index/fund symbols
+    to ensure the correct associated name is returned.
+
+    Args:
+        symbol: Company/index/fund symbol.
+        expected_result: Expected name to be returned.
+    """
     name = finance.get_name_from_symbol(symbol)
     assert type(name) is str
     assert name == expected_result
 
 
 def test_get_name_from_symbol_invalid() -> None:
-    """ """
+    """
+    Tests get_name_from_symbol using an invalid symbol to ensure a
+    blank name is returned.
+    """
     name = finance.get_name_from_symbol("INVALID")
     assert type(name) == str
     assert name == ""
 
 
 @pytest.mark.parametrize(
-    "name", [("Tesla"), ("FTSE 100"), ("T. Rowe Price Funds OEIC Asian ")]
+    "name",
+    [
+        ("Tesla"),
+        ("FTSE 100"),
+        ("T. Rowe Price Funds OEIC Asian Opportunities Equity Fund Class C GBP"),
+    ],
 )
 def test_get_history_valid(name: str) -> None:
-    """ """
+    """
+    Tests the get_history method with valid names to ensure
+    the recent pricing history of each is returned.
+
+    Args:
+        name: Name of the company/index/OEIC.
+    """
     history = finance.get_history(name)
     assert history is not None
     assert type(history) is pd.DataFrame
 
 
 def test_get_history_invalid() -> None:
-    pass
+    """
+    Tests the get_history method with an invalid company name to ensure
+    an error is thrown and no data is returned.
+    """
+    try:
+        finance.get_history("INVALID")
+        assert False
+    except IndexError:
+        assert True
+
+
+@pytest.mark.parametrize(
+    "symbol, expected_type, expected_currency",
+    [
+        ("AAPL", "EQUITY", "USD"),
+        ("0P0001BVXP.L", "MUTUALFUND", "GBP"),
+        ("^FTSE", "INDEX", "GBP"),
+    ],
+)
+def test_get_info_valid(
+    symbol: str, expected_type: str, expected_currency: str
+) -> None:
+    """
+    Tests the get_info method using valid symbols to ensure pricing data
+    and information about the index/company/OEIC is retrieved.
+
+    Args:
+        symbol: Listed symbol.
+        expected_type: Expected type of the asset (Equity, Index, Mutual Fund).
+        expected_currency: Expected currency the asset is traded in.
+    """
+    info = finance.get_info(symbol)
+    assert info["currency"] == expected_currency
+    assert info["type"] == expected_type
+    assert info["current_value"] >= 0
+
+
+def test_get_info_lse() -> None:
+    """
+    Tests the get_info method using a stock listed on the London Stock Exchange
+    to ensure that GBX is converted to GBP.
+    """
+    symbol = "LSEG.L"
+    ticker = yf.Ticker(symbol)
+    info = finance.get_info(symbol)
+    assert info["current_value"] == (ticker.info["currentPrice"] / 100)
+    assert info["currency"] == "GBP"
+
+
+def test_get_info_invalid() -> None:
+    """
+    Tests the get_info method using an invalid symbol to ensure an error is
+    thrown.
+    """
+    try:
+        finance.get_info("INVALID")
+        assert False
+    except exceptions.HTTPError:
+        assert True
+
+
+@pytest.mark.parametrize(
+    "current, purchase, expected_result",
+    [
+        (10, 5, 100),
+        (5, 10, -50),
+        (0, 0, 0),
+    ],
+)
+def test_get_absolute_rate_of_return_valid(
+    current: float, purchase: float, expected_result: float
+) -> None:
+    """
+    Tests the get_absolute_rate_of_return method using valid current and
+    purchase prices of an asset.
+
+    Args:
+        current: Current price of the asset.
+        purchase: Purchase price of the asset.
+        expected_result: Expected absolute rate of return
+    """
+    calculated_ror = finance.get_absolute_rate_of_return(current, purchase)
+    assert calculated_ror == expected_result
+
+
+def test_get_absolute_rate_of_return_no_purchase_price() -> None:
+    """
+    Tests the get_absolute_rate_of_return method whilst passing no purchase
+    price into the method.
+    """
+    calculated_ror = finance.get_absolute_rate_of_return(100, None)
+    assert calculated_ror == 0

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -9,14 +9,14 @@ from src import finance, app
 
 DB_PATH = "resources/test.db"
 
+
 @pytest.fixture
 def setup_and_teardown_database():
-    """
-    
-    """
+    """ """
     app.create_database_tables(DB_PATH)
     yield
     os.remove(DB_PATH)
+
 
 @pytest.mark.parametrize(
     "name, expected_result",
@@ -216,29 +216,20 @@ def test_get_rate_of_return_invalid() -> None:
 
 
 def test_upsert_transaction_into_portfolio_valid_buy(
-    setup_and_teardown_database: function
-    ) -> None:
-    """ 
-    
-    """
+    setup_and_teardown_database,
+) -> None:
+    """ """
     finance.upsert_transaction_into_portfolio(
-        "buy",
-        "BTC-USD",
-        "USD",
-        1000,
-        100,
-        100,
-        DB_PATH
+        "buy", "BTC-USD", "USD", 1000, 100, 100, DB_PATH
     )
-    
+
     with duckdb.connect(DB_PATH) as conn:
         result = conn.execute(
             "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
             "WHERE symbol = ?",
-            ("BTC-USD",)
+            ("BTC-USD",),
         ).fetchone()
-    
-    
+
     if result:
         symbol, _, units, currency, paid, _ = result
         assert symbol == "BTC-USD"
@@ -248,49 +239,41 @@ def test_upsert_transaction_into_portfolio_valid_buy(
     else:
         assert False
 
+
 def test_upsert_transaction_into_portfolio_valid_sell(
-    setup_and_teardown_database
-    ) -> None:
+    setup_and_teardown_database,
+) -> None:
     pass
+
 
 def test_upsert_transaction_into_portfolio_invalid_sell(
-    setup_and_teardown_database
-    ) -> None:
+    setup_and_teardown_database,
+) -> None:
     """ """
     pass
 
 
-def test_remove_security_from_portfolio_valid(
-    setup_and_teardown_database
-    ) -> None:
+def test_remove_security_from_portfolio_valid(setup_and_teardown_database) -> None:
     """ """
     pass
 
 
-def test_remove_security_from_portfolio_valid(
-    setup_and_teardown_database
-    ) -> None:
+def test_remove_security_from_portfolio_valid(setup_and_teardown_database) -> None:
     """ """
     pass
 
 
-def test_remove_security_from_portfolio_invalid(
-    setup_and_teardown_database
-    ) -> None:
+def test_remove_security_from_portfolio_invalid(setup_and_teardown_database) -> None:
     """ """
     pass
 
 
-def test_get_total_paid_into_portfolio_valid(
-    setup_and_teardown_database
-    ) -> None:
+def test_get_total_paid_into_portfolio_valid(setup_and_teardown_database) -> None:
     """ """
     pass
 
 
-def test_get_total_paid_into_portfolio_empty(
-    setup_and_teardown_database
-    ) -> None:
+def test_get_total_paid_into_portfolio_empty(setup_and_teardown_database) -> None:
     """ """
     pass
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,10 +1,22 @@
+import duckdb
 import pytest
+import os
 import pandas as pd
 import yfinance as yf
 
 from requests import exceptions
-from src import finance
+from src import finance, app
 
+DB_PATH = "resources/test.db"
+
+@pytest.fixture
+def setup_and_teardown_database():
+    """
+    
+    """
+    app.create_database_tables(DB_PATH)
+    yield
+    os.remove(DB_PATH)
 
 @pytest.mark.parametrize(
     "name, expected_result",
@@ -203,48 +215,82 @@ def test_get_rate_of_return_invalid() -> None:
     assert calculated_ror == 0
 
 
-# TODO: Work out DB_PATH testing DB
-def test_upsert_transaction_into_portfolio_valid_buy() -> None:
+def test_upsert_transaction_into_portfolio_valid_buy(
+    setup_and_teardown_database: function
+    ) -> None:
+    """ 
+    
+    """
+    finance.upsert_transaction_into_portfolio(
+        "buy",
+        "BTC-USD",
+        "USD",
+        1000,
+        100,
+        100,
+        DB_PATH
+    )
+    
+    with duckdb.connect(DB_PATH) as conn:
+        result = conn.execute(
+            "SELECT symbol, name, units, currency, paid, paid_gbp FROM portfolio "
+            "WHERE symbol = ?",
+            ("BTC-USD",)
+        ).fetchone()
+    
+    
+    if result:
+        symbol, _, units, currency, paid, _ = result
+        assert symbol == "BTC-USD"
+        assert float(units) == 10
+        assert currency == "USD"
+        assert float(paid) == 1000
+    else:
+        assert False
+
+def test_upsert_transaction_into_portfolio_valid_sell(
+    setup_and_teardown_database
+    ) -> None:
+    pass
+
+def test_upsert_transaction_into_portfolio_invalid_sell(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 
 
-def test_upsert_transaction_into_portfolio_invalid_buy() -> None:
+def test_remove_security_from_portfolio_valid(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 
 
-def test_upsert_transaction_into_portfolio_valid_sell() -> None:
+def test_remove_security_from_portfolio_valid(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 
 
-def test_upsert_transaction_into_portfolio_invalid_sell() -> None:
+def test_remove_security_from_portfolio_invalid(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 
 
-def test_remove_security_from_portfolio_valid() -> None:
+def test_get_total_paid_into_portfolio_valid(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 
 
-def test_remove_security_from_portfolio_valid() -> None:
-    """ """
-    pass
-
-
-def test_remove_security_from_portfolio_invalid() -> None:
-    """ """
-    pass
-
-
-def test_get_total_paid_into_portfolio_valid() -> None:
-    """ """
-    pass
-
-
-def test_get_total_paid_into_portfolio_empty() -> None:
+def test_get_total_paid_into_portfolio_empty(
+    setup_and_teardown_database
+    ) -> None:
     """ """
     pass
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -192,3 +192,137 @@ def test_get_absolute_rate_of_return_no_purchase_price() -> None:
     """
     calculated_ror = finance.get_absolute_rate_of_return(100, None)
     assert calculated_ror == 0
+
+
+def test_get_absolute_rate_of_return_invalid() -> None:
+    """
+    Tests the get_absolute_rate_of_return method whilst passing no purchase
+    and current price into the method
+    """
+    calculated_ror = finance.get_absolute_rate_of_return(None, None)
+    assert calculated_ror == 0
+
+
+# TODO: Work out DB_PATH testing DB
+def test_upsert_transaction_into_portfolio_valid_buy() -> None:
+    """ """
+    pass
+
+
+def test_upsert_transaction_into_portfolio_invalid_buy() -> None:
+    """ """
+    pass
+
+
+def test_upsert_transaction_into_portfolio_valid_sell() -> None:
+    """ """
+    pass
+
+
+def test_upsert_transaction_into_portfolio_invalid_sell() -> None:
+    """ """
+    pass
+
+
+def test_remove_security_from_portfolio_valid() -> None:
+    """ """
+    pass
+
+
+def test_remove_security_from_portfolio_valid() -> None:
+    """ """
+    pass
+
+
+def test_remove_security_from_portfolio_invalid() -> None:
+    """ """
+    pass
+
+
+def test_get_total_paid_into_portfolio_valid() -> None:
+    """ """
+    pass
+
+
+def test_get_total_paid_into_portfolio_empty() -> None:
+    """ """
+    pass
+
+
+@pytest.mark.parametrize(
+    "original_currency, currency_to", [("GBP", "USD"), ("USD", "JPY"), ("JPY", "GBP")]
+)
+def test_get_exchange_rate_valid(original_currency: str, currency_to: str) -> None:
+    """
+    Tests the get_exchange_rate method providing valid currencies to ensure
+    the most recent exchange rate is retrieved.
+
+    Args:
+        original_currency: Currency to convert from.
+        currency_to: Currency to convert to.
+    """
+    exch_rate = finance.get_exchange_rate(original_currency, currency_to)
+    assert exch_rate
+    assert exch_rate > 0
+
+
+@pytest.mark.parametrize(
+    "currency",
+    [
+        ("GBP"),
+        ("EUR"),
+        ("USD"),
+    ],
+)
+def test_get_exchange_rate_same_currency(currency: str) -> None:
+    """
+    Tests the get_exchange_rate method providing the same currency to convert
+    to. The exchange rate between the same currency should be 1.
+
+    Args:
+        currency: Currency to convert from and to.
+    """
+    assert finance.get_exchange_rate(currency, currency) == 1
+
+
+@pytest.mark.parametrize(
+    "provided_date",
+    [
+        ("1999-01-04"),
+        ("2023-07-01"),
+        ("2002-08-03"),
+    ],
+)
+def test_get_exchange_rate_valid_date(provided_date: str) -> None:
+    """
+    Tests the get_exchange_rate method providing a valid date.
+
+    Args:
+        provided_date: Date to retrieve the exchange rate from.
+    """
+    exch_rate = finance.get_exchange_rate("GBP", "USD", provided_date)
+    assert exch_rate
+    assert exch_rate > 0
+
+
+def test_get_exchange_rate_too_old_date() -> None:
+    """
+    Tests the get_exchange_rate method providing a date that is too old for
+    the Frankfurter API to ensure the oldest possible exchange rate is
+    retrieved.
+    """
+    exch_rate = finance.get_exchange_rate("GBP", "USD", "1900-01-01")
+    exch_rate_oldest = finance.get_exchange_rate("GBP", "USD", "1999-01-04")
+
+    assert exch_rate == exch_rate_oldest
+
+
+def test_get_exchange_rate_invalid_date() -> None:
+    """
+    Tests the get_exchange_rate method providing an invalid date.
+    """
+    try:
+        finance.get_exchange_rate("GBP", "USD", "INVALID")
+        assert False
+    except ValueError:
+        assert True

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,0 +1,70 @@
+import pytest
+import pandas as pd
+
+from src import finance
+
+
+@pytest.mark.parametrize(
+    "name, expected_result",
+    [
+        ("Apple", "AAPL"),
+        ("FTSE 100", "^FTSE"),
+        (
+            "T. Rowe Price Funds OEIC Asian Opportunities Equity Fund Class C GBP",
+            "0P0001BVXP.L",
+        ),
+    ],
+)
+def test_get_symbol_valid(name: str, expected_result: str) -> None:
+    """ """
+    symbol = finance.get_symbol(name)
+    assert type(symbol) is str
+    assert symbol == expected_result
+
+
+def test_get_symbol_invalid() -> None:
+    """ """
+    try:
+        finance.get_symbol("Invalid")
+        assert False
+    except IndexError:
+        assert True
+
+
+@pytest.mark.parametrize(
+    "symbol, expected_result",
+    [
+        ("TSLA", "Tesla, Inc."),
+        ("^FTSE", "FTSE 100"),
+        (
+            "0P0001BVXP.L",
+            "T. Rowe Price Funds OEIC Asian Opportunities Equity Fund Class C GBP",
+        ),
+    ],
+)
+def test_get_name_from_symbol_valid(symbol: str, expected_result: str) -> None:
+    """ """
+    name = finance.get_name_from_symbol(symbol)
+    assert type(name) is str
+    assert name == expected_result
+
+
+def test_get_name_from_symbol_invalid() -> None:
+    """ """
+    name = finance.get_name_from_symbol("INVALID")
+    assert type(name) == str
+    assert name == ""
+
+
+@pytest.mark.parametrize(
+    "name", [("Tesla"), ("FTSE 100"), ("T. Rowe Price Funds OEIC Asian ")]
+)
+def test_get_history_valid(name: str) -> None:
+    """ """
+    history = finance.get_history(name)
+    assert history is not None
+    assert type(history) is pd.DataFrame
+
+
+def test_get_history_invalid() -> None:
+    pass

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,7 +1,2 @@
 import pytest
 import coverage
-
-
-def test_invalid_transaction():
-    security = False
-    assert isinstance(security, str) is False


### PR DESCRIPTION
### Summary

- Added non-database related unit tests for the finance.py module in the test_finance.py module.
- These tests can be run using pytest.
- Additional changes to the codebase involve adding a "database_path" parameter to all functions which make connection with the DB. This has been done for testing purposes so that a test DB can be created when running unit tests.

Contributes to #30.