### PR TITLE
Run pytest workflow on macOS instead of Ubuntu

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     # The type of runner that the job will run on.
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     # Configures the build to use the latest version of Python 3.
     strategy:
       matrix:
@@ -38,4 +38,4 @@ jobs:
         run: coverage run --source=src -m pytest -v
 
       - name: Get code coverage report
-        run: coverage report -m 
+        run: coverage report -m

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Compatible with:
 
 - macOS
 - Windows
-- Linux
+<!-- Test Linux compatibility with PyQt6, as Linux doesn't work with PySide6. -->
 
 ### Python Version
 


### PR DESCRIPTION
## Summary
- The CI pipeline currently fails due to an issue with PySide6 and Ubuntu, so we should run it on macOS.
  - It seems like it's a PySide6 problem, so we could look into whether this also occurs with PyQt6, as it would be an easy port.
- While the CI pipeline for pytest still fails, it's due to changes in the `yfinance` API. The fixes for this are separate to these changes.