### PR TITLE
Fix absolute rate of return displayed per asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ cython_debug/
 
 # DB files - these are binary files which causes version control conflicts.
 *.db
+*.duckdb

--- a/src/trading_portfolio_tracker/app.py
+++ b/src/trading_portfolio_tracker/app.py
@@ -6,7 +6,7 @@ from PySide6 import QtWidgets
 
 from src.trading_portfolio_tracker.portfolio import MainWindow
 
-DB_PATH = "resources/portfolio.db"
+DB_PATH = "resources/portfolio.duckdb"
 
 
 def main() -> None:

--- a/src/trading_portfolio_tracker/finance.py
+++ b/src/trading_portfolio_tracker/finance.py
@@ -12,7 +12,7 @@ import requests
 import yfinance as yf
 from requests import exceptions
 
-DB_PATH = "resources/portfolio.db"
+DB_PATH = "resources/portfolio.duckdb"
 
 
 def get_symbol(name: str) -> str:

--- a/src/trading_portfolio_tracker/portfolio.py
+++ b/src/trading_portfolio_tracker/portfolio.py
@@ -36,7 +36,7 @@ from src.trading_portfolio_tracker.ui.transaction_history_ui import (
     Ui_dialog_transaction_history,
 )
 
-DB_PATH = "resources/portfolio.db"
+DB_PATH = "resources/portfolio.duckdb"
 
 
 class UpdateStockPricesWorker(QObject):
@@ -275,7 +275,7 @@ class MainWindow(QMainWindow, Ui_main_window):
             cur_val_gbp = cur_val * exchange_rate
 
             val_change = cur_val_gbp - security.paid_gbp
-            rate_of_return_abs = get_rate_of_return(cur_val_gbp, security.paid)
+            rate_of_return_abs = get_rate_of_return(cur_val_gbp, security.paid_gbp)
 
             # Stores the live security information in a dictionary indexed
             # by the name of the security
@@ -363,7 +363,7 @@ class MainWindow(QMainWindow, Ui_main_window):
                 row,
                 8,
                 QtWidgets.QTableWidgetItem(
-                    f"{self.current_security_info[security.name][2]:+.2f}%"
+                    f"{self.current_security_info[security.name][2]:+.3f}%"
                 ),
             )
 

--- a/src/trading_portfolio_tracker/transactions.py
+++ b/src/trading_portfolio_tracker/transactions.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 import duckdb
 
-DB_PATH = "resources/portfolio.db"
+DB_PATH = "resources/portfolio.duckdb"
 
 
 @dataclass

--- a/utils/export_duckdb.py
+++ b/utils/export_duckdb.py
@@ -8,7 +8,7 @@ import duckdb
 
 def main():
     # The directory to get the DB file from.
-    export_from = "resources/portfolio.db"
+    export_from = "resources/portfolio.duckdb"
     # The directory to export the DB to.
     export_to = "resources/portfolio_data"
 

--- a/utils/import_duckdb.py
+++ b/utils/import_duckdb.py
@@ -11,7 +11,7 @@ def main():
     # The directory to import the DB file from.
     import_from = "resources/portfolio_data"
     # The directory to load the DB into.
-    import_to = "resources/portfolio.db"
+    import_to = "resources/portfolio.duckdb"
 
     conn = duckdb.connect(import_to)
     conn.execute(f"IMPORT DATABASE '{import_from}'")


### PR DESCRIPTION
## Summary
- Previously, the absolute rate of return displayed per asset (per row in the portfolio table) used the ratio between the current value in GBP and the amount paid in the native currency.
  - This caused an incorrect calculation, which has now been fixed.
- Changed DB file from `.db` to `.duckdb` for clarity.