### PR TITLE
Fix Yahoo price fallback

### DIFF
--- a/src/trading_portfolio_tracker/finance.py
+++ b/src/trading_portfolio_tracker/finance.py
@@ -74,7 +74,7 @@ def get_history(name: str, period: str = "1mo") -> pd.DataFrame:
     return tick.history(period=period)
 
 
-def get_info(symbol: str) -> dict[str, str]:
+def get_info(symbol: str) -> dict[str, str | float]:
     """
     Returns information about a stock/company.
     Accounts for the difference in the yfinance library in returning
@@ -89,22 +89,21 @@ def get_info(symbol: str) -> dict[str, str]:
     """
     # Creates a yfinance ticker object for a given asset.
     ticker = yf.Ticker(symbol)
+    info = ticker.info
 
     # Creates a dictionary containing basic information about the asset.
     return_dict = {
-        "name": ticker.info["shortName"],
-        "ticker": ticker.info["symbol"],
-        "type": ticker.info["quoteType"],
+        "name": info["shortName"],
+        "ticker": info["symbol"],
+        "type": info["quoteType"],
     }
 
-    # Tries to get information about a stock/index/fund but if the data is
-    # unavailable in the usual format, the most recent data about that asset is
-    # downloaded and retrieved using the download method of yfinance.
-    try:
-        return_dict["current_value"] = ticker.info["currentPrice"]
-        return_dict["currency"] = ticker.info["financialCurrency"]
-        return_dict["sector"] = ticker.info["sector"]
-    except KeyError:
+    current_value = info.get("currentPrice")
+    if current_value is None:
+        current_value = info.get("regularMarketPrice")
+
+    # Download the latest close if Yahoo's quote data has no current price.
+    if current_value is None:
         date_range = "1d"
 
         # If the type is a mutual fund then change the data download period to
@@ -113,16 +112,28 @@ def get_info(symbol: str) -> dict[str, str]:
             date_range = "1mo"
 
         # Downloads the most recent data associated with the asset.
-        data = yf.download(return_dict["ticker"], period=date_range, progress=False)
-        last_row_index = len(data) - 1
-        # Gets the last reported close price of the asset
-        last_row_open_value = data.iloc[last_row_index]["Close"]
-        return_dict["current_value"] = last_row_open_value
-        return_dict["currency"] = ticker.info["currency"]
+        data = yf.download(
+            return_dict["ticker"],
+            period=date_range,
+            progress=False,
+            auto_adjust=False,
+        )
+        if data.empty:
+            raise ValueError(f"No price data found for {symbol}.")
+        close_prices = data["Close"]
+        if isinstance(close_prices, pd.DataFrame):
+            current_value = float(close_prices.iloc[-1, 0])
+        else:
+            current_value = float(close_prices.iloc[-1])
 
-    # Checks if the stock is traded on the LSE, if so GBP is converted to GBX.
-    if ticker.info["symbol"][-2:] == ".L":
-        return_dict["current_value"] /= 100
+    return_dict["current_value"] = current_value
+    return_dict["currency"] = info.get("financialCurrency") or info["currency"]
+    if sector := info.get("sector"):
+        return_dict["sector"] = sector
+
+    # Convert prices reported in pence to pounds.
+    if info.get("currency") in {"GBp", "GBX"}:
+        return_dict["current_value"] = current_value / 100
         return_dict["currency"] = "GBP"
 
     return return_dict

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -1,10 +1,10 @@
 import os
 from decimal import Decimal
+from types import SimpleNamespace
 
 import duckdb
 import pandas as pd
 import pytest
-import yfinance as yf
 
 from src.trading_portfolio_tracker import app, finance
 
@@ -116,15 +116,57 @@ def test_get_history_invalid() -> None:
 
 
 @pytest.mark.parametrize(
-    "symbol, expected_type, expected_currency",
+    "symbol, ticker_info, expected_type, expected_currency, expected_value",
     [
-        ("AAPL", "EQUITY", "USD"),
-        ("0P0001BVXP.L", "MUTUALFUND", "GBP"),
-        ("^FTSE", "INDEX", "GBP"),
+        (
+            "AAPL",
+            {
+                "shortName": "Apple Inc.",
+                "symbol": "AAPL",
+                "quoteType": "EQUITY",
+                "currentPrice": 200.0,
+                "financialCurrency": "USD",
+                "sector": "Technology",
+            },
+            "EQUITY",
+            "USD",
+            200.0,
+        ),
+        (
+            "0P0001BVXP.L",
+            {
+                "shortName": "Fund",
+                "symbol": "0P0001BVXP.L",
+                "quoteType": "MUTUALFUND",
+                "regularMarketPrice": 18.0897,
+                "currency": "GBP",
+            },
+            "MUTUALFUND",
+            "GBP",
+            18.0897,
+        ),
+        (
+            "^FTSE",
+            {
+                "shortName": "FTSE 100",
+                "symbol": "^FTSE",
+                "quoteType": "INDEX",
+                "regularMarketPrice": 8_000.0,
+                "currency": "GBP",
+            },
+            "INDEX",
+            "GBP",
+            8_000.0,
+        ),
     ],
 )
 def test_get_info_valid(
-    symbol: str, expected_type: str, expected_currency: str
+    monkeypatch: pytest.MonkeyPatch,
+    symbol: str,
+    ticker_info: dict[str, str | float],
+    expected_type: str,
+    expected_currency: str,
+    expected_value: float,
 ) -> None:
     """
     Tests the get_info method using valid symbols to ensure pricing data
@@ -132,32 +174,114 @@ def test_get_info_valid(
 
     Args:
         symbol: Listed symbol.
+        ticker_info: Yahoo Finance response for the symbol.
         expected_type: Expected type of the asset (Equity, Index, Mutual Fund).
         expected_currency: Expected currency the asset is traded in.
+        expected_value: Expected current value of the asset.
     """
+    monkeypatch.setattr(
+        finance.yf,
+        "Ticker",
+        lambda requested_symbol: SimpleNamespace(info=ticker_info),
+    )
+
     info = finance.get_info(symbol)
     assert info["currency"] == expected_currency
     assert info["type"] == expected_type
-    assert float(info["current_value"]) >= 0.0
+    assert info["current_value"] == expected_value
 
 
-def test_get_info_lse() -> None:
+@pytest.mark.parametrize(
+    "history",
+    [
+        pd.DataFrame({"Close": [10.0, 11.0]}),
+        pd.DataFrame({("Close", "FUND"): [10.0, 11.0]}),
+    ],
+    ids=["flat-columns", "multi-index-columns"],
+)
+def test_get_info_falls_back_to_history(
+    monkeypatch: pytest.MonkeyPatch, history: pd.DataFrame
+) -> None:
+    """Use the latest close when Yahoo's quote data contains no price."""
+    ticker_info = {
+        "shortName": "Fund",
+        "symbol": "FUND",
+        "quoteType": "MUTUALFUND",
+        "currency": "GBP",
+    }
+    monkeypatch.setattr(
+        finance.yf,
+        "Ticker",
+        lambda symbol: SimpleNamespace(info=ticker_info),
+    )
+
+    def download(*args, **kwargs):
+        return history
+
+    monkeypatch.setattr(finance.yf, "download", download)
+
+    info = finance.get_info("FUND")
+
+    assert info["current_value"] == 11.0
+    assert info["currency"] == "GBP"
+
+
+def test_get_info_missing_price_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise a clear error when Yahoo returns no quote or price history."""
+    ticker_info = {
+        "shortName": "Fund",
+        "symbol": "FUND",
+        "quoteType": "MUTUALFUND",
+        "currency": "GBP",
+    }
+    monkeypatch.setattr(
+        finance.yf,
+        "Ticker",
+        lambda symbol: SimpleNamespace(info=ticker_info),
+    )
+    monkeypatch.setattr(finance.yf, "download", lambda *args, **kwargs: pd.DataFrame())
+
+    with pytest.raises(ValueError, match="No price data found for FUND"):
+        finance.get_info("FUND")
+
+
+def test_get_info_lse(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Tests the get_info method using a stock listed on the London Stock Exchange
     to ensure that GBX is converted to GBP.
     """
     symbol = "LSEG.L"
-    ticker = yf.Ticker(symbol)
+    ticker_info = {
+        "shortName": "London Stock Exchange Group plc",
+        "symbol": symbol,
+        "quoteType": "EQUITY",
+        "currentPrice": 8_774.0,
+        "currency": "GBp",
+        "financialCurrency": "GBP",
+        "sector": "Financial Services",
+    }
+    monkeypatch.setattr(
+        finance.yf,
+        "Ticker",
+        lambda requested_symbol: SimpleNamespace(info=ticker_info),
+    )
+
     info = finance.get_info(symbol)
-    assert info["current_value"] == (ticker.info["currentPrice"] / 100)
+    assert info["current_value"] == 87.74
     assert info["currency"] == "GBP"
 
 
-def test_get_info_invalid() -> None:
+def test_get_info_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Tests the get_info method using an invalid symbol to ensure an error is
     thrown.
     """
+    monkeypatch.setattr(
+        finance.yf,
+        "Ticker",
+        lambda symbol: SimpleNamespace(info={}),
+    )
+
     with pytest.raises(KeyError):
         finance.get_info("INVALID")
 


### PR DESCRIPTION
# Summary
- Used Yahoo's regular market price before falling back to historical downloads
	- Prevented valid instruments without `currentPrice` from failing when recent history is empty
- Added explicit handling for empty price history and both flat and multi-index download results
- Converted London prices only when Yahoo reports the quote in pence
	- Avoided dividing mutual fund prices that are already reported in pounds
- Replaced live Yahoo calls in the affected tests with deterministic responses
- Validated the change with the full 40-test suite, coverage command, Ruff checks, and a live lookup of the previously failing fund
